### PR TITLE
feat: Add sonar workflow

### DIFF
--- a/.github/workflows/template-sonar.yml
+++ b/.github/workflows/template-sonar.yml
@@ -7,12 +7,6 @@ jobs:
     name: Analyze
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Java 21
-        uses: actions/setup-java@v4
-        with:
-          java-version: 21
-          distribution: 'microsoft'
-          
       - name: Set up dotnet version
         uses: actions/setup-dotnet@v4
         with: 

--- a/.github/workflows/template-sonar.yml
+++ b/.github/workflows/template-sonar.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   build:
-    name: Analyze solution
+    name: Analyze
     runs-on: ubuntu-latest
     steps:
       - name: Set up Java 21

--- a/.github/workflows/template-sonar.yml
+++ b/.github/workflows/template-sonar.yml
@@ -1,0 +1,49 @@
+name: Sonar
+on:
+  workflow_call:
+
+jobs:
+  build:
+    name: Analyze solution
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Java 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: 'microsoft'
+          
+      - name: Set up dotnet version
+        uses: actions/setup-dotnet@v4
+        with: 
+          dotnet-version: 8.0.x
+
+      - name: Checkout 
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          
+      - name: Install sonar scanner
+        run: dotnet tool install -g dotnet-sonarscanner    
+        
+      - name: Cache sonar
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+
+      - name: Restore
+        working-directory: './src' 
+        run: dotnet restore
+          
+      - name: Analyze
+        working-directory: './src' 
+        run: |
+          dotnet sonarscanner begin /k:"${{ env.PROJECT_KEY }}" /o:"${{ env.ORGANIZATION }}" /d:sonar.token="${{ env.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.dotnet.excludeTestProjects=true
+          dotnet build MudBlazor/MudBlazor.csproj -c Release --no-restore --no-incremental
+          dotnet sonarscanner end /d:sonar.token="${{ env.SONAR_TOKEN }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          PROJECT_KEY: MudBlazor_MudBlazor
+          ORGANIZATION: mudblazor


### PR DESCRIPTION
This PR introduces the initial version of the SonarCloud workflow. https://github.com/MudBlazor/MudBlazor/issues/9236


- Analyzes `MudBlazor`, `MudBlazor.SourceGenerator`, and `MudBlazor.Analyzers` projects.
- Requires secrets from the calling workflow.
- Doesn't depend on any other workflow.


### Not included
- This PR does not include any code coverage-related features.

The calling workflow currently looks like this:
```yml
name: sonar

on:
  workflow_dispatch:
  push:
    branches:
      - dev

concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true

jobs:
  analyze:
    name: Analyze
    uses: MudBlazor/Workflows/.github/workflows/template-sonar.yml@main
    secrets: inherit
```