### PR TITLE
Build: Add Sonar PR decoration

### DIFF
--- a/.github/workflows/template-build-test.yml
+++ b/.github/workflows/template-build-test.yml
@@ -14,11 +14,6 @@ on:
         required: false
         type: string
         default: 'ga'
-      publish-coverage:
-        description: 'publish coverage to codecov'
-        required: false
-        type: boolean
-        default: true
       check-eslint:
         description: 'path to script folder you want to check for ES6 compliance'
         required: false
@@ -86,12 +81,11 @@ jobs:
         run: dotnet build -c Release --no-restore
 
       - name: Test
-        run: dotnet test -c Release --no-build --no-restore --blame-hang --blame-hang-timeout 60s /property:GenerateFullPaths=true /consoleloggerparameters:NoSummary /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:ExcludeByAttribute='ExcludeFromCodeCoverageAttribute' /p:ExcludeByAttribute='CompilerGeneratedAttribute' /p:ExcludeByFile='**/*.g.cs' /p:Include='[MudBlazor]*' /p:SkipAutoProps=true /p:CoverletOutput='./TestResults/'
+        run: dotnet test -c Release --no-build --no-restore --blame-hang --blame-hang-timeout 60s --collect:'XPlat Code Coverage;Format=opencover' --results-directory 'test-results' /p:ExcludeByAttribute='ExcludeFromCodeCoverageAttribute' /p:ExcludeByAttribute='CompilerGeneratedAttribute' /p:ExcludeByFile='**/*.g.cs' /p:SkipAutoProps=true
 
-      - name: Publish coverage
-        if: ${{ inputs.publish-coverage == true }}
-        uses: codecov/codecov-action@v4
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: coverage.cobertura.xml
+          name: coverage-report
+          path: test-results
 

--- a/.github/workflows/template-build-test.yml
+++ b/.github/workflows/template-build-test.yml
@@ -87,5 +87,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: coverage-report
-          path: TestResults
+          path: ./**/TestResults/coverage.opencover.xml
 

--- a/.github/workflows/template-build-test.yml
+++ b/.github/workflows/template-build-test.yml
@@ -81,11 +81,11 @@ jobs:
         run: dotnet build -c Release --no-restore
 
       - name: Test
-        run: dotnet test -c Release --no-build --no-restore --blame-hang --blame-hang-timeout 60s --collect 'XPlat Code Coverage;Format=opencover' --results-directory 'test-results' /property:GenerateFullPaths=true /consoleloggerparameters:NoSummary /p:ExcludeByAttribute='ExcludeFromCodeCoverageAttribute' /p:ExcludeByAttribute='CompilerGeneratedAttribute' /p:ExcludeByFile='**/*.g.cs' /p:SkipAutoProps=true
+        run: dotnet test -c Release --no-build --no-restore --blame-hang --blame-hang-timeout 60s /property:GenerateFullPaths=true /consoleloggerparameters:NoSummary /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:ExcludeByAttribute='ExcludeFromCodeCoverageAttribute' /p:ExcludeByAttribute='CompilerGeneratedAttribute' /p:ExcludeByFile='**/*.g.cs' /p:SkipAutoProps=true /p:CoverletOutput='./TestResults/'
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:
           name: coverage-report
-          path: test-results
+          path: TestResults
 

--- a/.github/workflows/template-build-test.yml
+++ b/.github/workflows/template-build-test.yml
@@ -81,7 +81,7 @@ jobs:
         run: dotnet build -c Release --no-restore
 
       - name: Test
-        run: dotnet test -c Release --no-build --no-restore --blame-hang --blame-hang-timeout 60s --collect 'XPlat Code Coverage;Format=opencover' --results-directory 'test-results' /p:ExcludeByAttribute='ExcludeFromCodeCoverageAttribute' /p:ExcludeByAttribute='CompilerGeneratedAttribute' /p:ExcludeByFile='**/*.g.cs' /p:SkipAutoProps=true
+        run: dotnet test -c Release --no-build --no-restore --blame-hang --blame-hang-timeout 60s --collect 'XPlat Code Coverage;Format=opencover' --results-directory 'test-results' /property:GenerateFullPaths=true /consoleloggerparameters:NoSummary /p:ExcludeByAttribute='ExcludeFromCodeCoverageAttribute' /p:ExcludeByAttribute='CompilerGeneratedAttribute' /p:ExcludeByFile='**/*.g.cs' /p:SkipAutoProps=true
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/template-build-test.yml
+++ b/.github/workflows/template-build-test.yml
@@ -81,7 +81,7 @@ jobs:
         run: dotnet build -c Release --no-restore
 
       - name: Test
-        run: dotnet test -c Release --no-build --no-restore --blame-hang --blame-hang-timeout 60s --collect:'XPlat Code Coverage;Format=opencover' --results-directory 'test-results' /p:ExcludeByAttribute='ExcludeFromCodeCoverageAttribute' /p:ExcludeByAttribute='CompilerGeneratedAttribute' /p:ExcludeByFile='**/*.g.cs' /p:SkipAutoProps=true
+        run: dotnet test -c Release --no-build --no-restore --blame-hang --blame-hang-timeout 60s --collect 'XPlat Code Coverage;Format=opencover' --results-directory 'test-results' /p:ExcludeByAttribute='ExcludeFromCodeCoverageAttribute' /p:ExcludeByAttribute='CompilerGeneratedAttribute' /p:ExcludeByFile='**/*.g.cs' /p:SkipAutoProps=true
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/template-sonar.yml
+++ b/.github/workflows/template-sonar.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
           
       - name: Install sonar scanner
-        run: dotnet tool install -g dotnet-sonarscanner    
+        run: dotnet tool install -g dotnet-sonarscanner --version 8.0.1
         
       - name: Cache sonar
         uses: actions/cache@v4

--- a/.github/workflows/template-sonar.yml
+++ b/.github/workflows/template-sonar.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Analyze
         working-directory: './src' 
         run: |
-          dotnet sonarscanner begin /k:"${{ env.PROJECT_KEY }}" /o:"${{ env.ORGANIZATION }}" /d:sonar.token="${{ env.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.dotnet.excludeTestProjects=true /d:sonar.scanner.scanAll=true /d:sonar.cs.opencover.reportsPaths="**/TestResults/**/coverage.opencover.xml"
+          dotnet sonarscanner begin /k:"${{ env.PROJECT_KEY }}" /o:"${{ env.ORGANIZATION }}" /d:sonar.token="${{ env.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.dotnet.excludeTestProjects=true /d:sonar.scanner.scanAll=true /d:sonar.cs.opencover.reportsPaths="**/TestResults/coverage.opencover.xml"
           dotnet build MudBlazor/MudBlazor.csproj -c Release --no-restore --no-incremental
           dotnet sonarscanner end /d:sonar.token="${{ env.SONAR_TOKEN }}"
         env:

--- a/.github/workflows/template-sonar.yml
+++ b/.github/workflows/template-sonar.yml
@@ -29,11 +29,17 @@ jobs:
       - name: Restore
         working-directory: './src' 
         run: dotnet restore
+
+      - name: Download coverage report
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-report
+          path: ./src/test-results
           
       - name: Analyze
         working-directory: './src' 
         run: |
-          dotnet sonarscanner begin /k:"${{ env.PROJECT_KEY }}" /o:"${{ env.ORGANIZATION }}" /d:sonar.token="${{ env.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.dotnet.excludeTestProjects=true
+          dotnet sonarscanner begin /k:"${{ env.PROJECT_KEY }}" /o:"${{ env.ORGANIZATION }}" /d:sonar.token="${{ env.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.dotnet.excludeTestProjects=true /d:sonar.scanner.scanAll=true /d:sonar.cs.opencover.reportsPaths="**/test-results/**/coverage.opencover.xml"
           dotnet build MudBlazor/MudBlazor.csproj -c Release --no-restore --no-incremental
           dotnet sonarscanner end /d:sonar.token="${{ env.SONAR_TOKEN }}"
         env:

--- a/.github/workflows/template-sonar.yml
+++ b/.github/workflows/template-sonar.yml
@@ -34,12 +34,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: coverage-report
-          path: ./src/test-results
+          path: ./src/TestResults
           
       - name: Analyze
         working-directory: './src' 
         run: |
-          dotnet sonarscanner begin /k:"${{ env.PROJECT_KEY }}" /o:"${{ env.ORGANIZATION }}" /d:sonar.token="${{ env.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.dotnet.excludeTestProjects=true /d:sonar.scanner.scanAll=true /d:sonar.cs.opencover.reportsPaths="**/test-results/**/coverage.opencover.xml"
+          dotnet sonarscanner begin /k:"${{ env.PROJECT_KEY }}" /o:"${{ env.ORGANIZATION }}" /d:sonar.token="${{ env.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.dotnet.excludeTestProjects=true /d:sonar.scanner.scanAll=true /d:sonar.cs.opencover.reportsPaths="**/TestResults/**/coverage.opencover.xml"
           dotnet build MudBlazor/MudBlazor.csproj -c Release --no-restore --no-incremental
           dotnet sonarscanner end /d:sonar.token="${{ env.SONAR_TOKEN }}"
         env:


### PR DESCRIPTION
- Remove CodeCov.
- Add Upload/Download coverage reports.
- Use `opencover` format for SonarCloud.
- Explicitly downgrade SonarScanner to version `8.0.1` due to [this issue](https://community.sonarsource.com/t/sonarscanner-for-net-8-now-with-other-languages-auto-detection/120563/18?u=xc0dex).

Needs to be merged before https://github.com/MudBlazor/MudBlazor/pull/9774.