### PR TITLE
Build: Downgrade codecov action to v3

### DIFF
--- a/.github/workflows/template-build-test.yml
+++ b/.github/workflows/template-build-test.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Publish coverage
         if: ${{ inputs.publish-coverage == true }}
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: coverage.cobertura.xml


### PR DESCRIPTION
This commit is being reverted: https://github.com/MudBlazor/Workflows/commit/48b21c826853991938cfb4131d85f2c1361abf4c.

I mentioned in Discord that Codecov hasn’t updated in six months and is stuck on an old commit in the dev branch, as you can see in the Codecov.io dashboard. This is unacceptable.

The time matches, the codecov action was updated on April 8, when the last commit on dev in codecov is registered on April 7.

It seems there was a breaking change in Codecov: https://github.com/codecov/codecov-action/issues/1248. Since I don’t have admin rights in the organization, I will temporarily downgrade the action as a solution.

cc @mikes-gh